### PR TITLE
Bump up to version to v1.6.1

### DIFF
--- a/cmd/rv/main.go
+++ b/cmd/rv/main.go
@@ -46,7 +46,7 @@ import (
 )
 
 // Current software version.
-const version = "v1.6.0"
+const version = "v1.6.1"
 
 // Copyright information prefixed to all metadata.
 const (


### PR DESCRIPTION
Now that Pull Request #11 has been merged, we need a new version for `rv`.
